### PR TITLE
a11y: reduced-motion guards + visually-hidden headings for demo apps

### DIFF
--- a/src/apps/basic/Basic/index.html
+++ b/src/apps/basic/Basic/index.html
@@ -5,10 +5,30 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>My Drawing</title>
+  <style>
+    /* Visually hidden: removed from view but kept in the accessibility tree so
+       the <h1> page heading is available for screen-reader navigation. */
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      overflow: hidden;
+      white-space: nowrap;
+    }
+  </style>
 </head>
 
 <body>
   <main>
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">My Drawing</h1>
     <canvas id="myCanvas" role="img"
       aria-label="A simple canvas sketch"></canvas>
   </main>

--- a/src/apps/basic/BouncyBall/bouncy_ball.js
+++ b/src/apps/basic/BouncyBall/bouncy_ball.js
@@ -1,6 +1,12 @@
 const canvas = document.getElementById('myCanvas');
 const ctx = canvas.getContext('2d');
 
+// Respect the user's "reduce motion" OS/browser setting (accessibility). When
+// it's on, we draw the ball once and don't start the bouncing loop.
+const reducedMotionQuery =
+  window.matchMedia?.('(prefers-reduced-motion: reduce)');
+let rafId = 0;
+
 // Ball properties
 const ballRadius = canvas.width * 0.1;
 const ballColor = 'red';
@@ -43,7 +49,25 @@ function animate() {
 
   drawBall();
   moveBall();
-  requestAnimationFrame(animate);
+  rafId = requestAnimationFrame(animate);
+}
+
+// Draw the ball once, without moving it (used when motion is reduced).
+function drawStaticFrame() {
+  ctx.fillStyle = bgColor;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  drawBall();
+}
+
+// Start bouncing — or, if the user prefers reduced motion, just draw the ball
+// as a single static frame instead of animating.
+function start() {
+  cancelAnimationFrame(rafId);
+  if (reducedMotionQuery?.matches) {
+    drawStaticFrame();
+  } else {
+    rafId = requestAnimationFrame(animate);
+  }
 }
 
 function resizeCanvas() {
@@ -61,8 +85,15 @@ function resizeCanvas() {
   maxSpeed = Math.max(3, canvas.height * 0.01);
   xSpeed = Math.random() * maxSpeed * initialDir; // Random x velocity
   ySpeed = Math.random() * maxSpeed * initialDir; // Random y velocity
+
+  // No loop runs under reduced motion, so repaint the static frame ourselves.
+  if (reducedMotionQuery?.matches) drawStaticFrame();
 }
 
 window.addEventListener('resize', resizeCanvas);
 resizeCanvas();
-animate();
+start();
+
+// If the user toggles "reduce motion" while the page is open, react live
+// (start bouncing, or freeze to the static frame) without a reload.
+reducedMotionQuery?.addEventListener?.('change', start);

--- a/src/apps/basic/BouncyBall/index.html
+++ b/src/apps/basic/BouncyBall/index.html
@@ -11,6 +11,10 @@
 
 <body>
   <main class="container">
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Bouncy Ball</h1>
     <canvas id="myCanvas" role="img"
       aria-label="Animation: a ball bouncing around inside the canvas"></canvas>
   </main>

--- a/src/apps/basic/BouncyBall/style.css
+++ b/src/apps/basic/BouncyBall/style.css
@@ -15,3 +15,18 @@ canvas {
   margin: 20px;
   height: calc(100vh - 40px); /* Subtract 20px from top and 20px from bottom */
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/graphics/LineSegment1-Basic/index.html
+++ b/src/apps/graphics/LineSegment1-Basic/index.html
@@ -18,6 +18,10 @@
 
 <body>
   <main class="container">
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Line Segment 1: Basic</h1>
     <canvas id="myCanvas" role="img"
       aria-label="A line segment drawn on a canvas, labeled with its angle and magnitude"></canvas>
   </main>

--- a/src/apps/graphics/LineSegment1-Basic/style.css
+++ b/src/apps/graphics/LineSegment1-Basic/style.css
@@ -9,3 +9,18 @@ canvas {
   width: 400px;
   height: 400px;
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/graphics/LineSegment2-Interactive/index.html
+++ b/src/apps/graphics/LineSegment2-Interactive/index.html
@@ -18,6 +18,10 @@
 
 <body>
   <main class="container">
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Line Segment 2: Interactive</h1>
     <canvas id="myCanvas" role="img"
       aria-label="Two line segments on a canvas; drag an endpoint to change the angle between them, shown with labeled arcs"></canvas>
   </main>

--- a/src/apps/graphics/LineSegment2-Interactive/style.css
+++ b/src/apps/graphics/LineSegment2-Interactive/style.css
@@ -9,3 +9,18 @@ canvas {
   width: 400px;
   height: 400px;
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/makelogo/MakeabilityLabLogo-AutoResize/index.html
+++ b/src/apps/makelogo/MakeabilityLabLogo-AutoResize/index.html
@@ -18,6 +18,10 @@
 
 <body>
   <main class="container">
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Makeability Lab Logo: Autoresize</h1>
     <canvas id="myCanvas" role="img"
       aria-label="The Makeability Lab logo, automatically resized to fill the window"></canvas>
   </main>

--- a/src/apps/makelogo/MakeabilityLabLogo-AutoResize/style.css
+++ b/src/apps/makelogo/MakeabilityLabLogo-AutoResize/style.css
@@ -16,3 +16,18 @@ canvas {
   width: 100%;
   height: 100%;
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/makelogo/MakeabilityLabLogo-ReverseExplosion/index.html
+++ b/src/apps/makelogo/MakeabilityLabLogo-ReverseExplosion/index.html
@@ -19,6 +19,10 @@
 
 <body>
   <main class="container">
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Makeability Lab Logo: Reverse Explosion</h1>
     <canvas id="myCanvas" role="img"
       aria-label="Animation: the scattered triangles of the Makeability Lab logo fly back together to form the logo"></canvas>
   </main>

--- a/src/apps/makelogo/MakeabilityLabLogo-ReverseExplosion/style.css
+++ b/src/apps/makelogo/MakeabilityLabLogo-ReverseExplosion/style.css
@@ -9,3 +9,18 @@ canvas {
   width: 1000px;
   height: 1000px;
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/makelogo/MakeabilityLabLogo-ReverseExplosion2/index.html
+++ b/src/apps/makelogo/MakeabilityLabLogo-ReverseExplosion2/index.html
@@ -19,6 +19,10 @@
 
 <body>
   <main class="container">
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Makeability Lab Logo: Reverse Explosion 2</h1>
     <canvas id="myCanvas" role="img"
       aria-label="Animation: the scattered triangles of the Makeability Lab logo fly back together to form the logo"></canvas>
   </main>

--- a/src/apps/makelogo/MakeabilityLabLogo-ReverseExplosion2/style.css
+++ b/src/apps/makelogo/MakeabilityLabLogo-ReverseExplosion2/style.css
@@ -9,3 +9,18 @@ canvas {
   width: 1000px;
   height: 1000px;
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/makelogo/MakeabilityLabLogo-SantaMorph/index.html
+++ b/src/apps/makelogo/MakeabilityLabLogo-SantaMorph/index.html
@@ -18,6 +18,10 @@
 
 <body>
   <main class="container">
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Makeability Lab Logo Santa Morph</h1>
     <canvas id="myCanvas" role="img"
       aria-label="Animation: the Makeability Lab logo morphs into a Santa Claus figure"></canvas>
   </main>

--- a/src/apps/makelogo/MakeabilityLabLogo-SantaMorph/sketch.js
+++ b/src/apps/makelogo/MakeabilityLabLogo-SantaMorph/sketch.js
@@ -90,6 +90,13 @@ let originalSantaTriangles = null;
 /** @type {number} Current mouse/touch x-coordinate relative to the canvas. */
 let mouseX = 0;
 
+// Respect the user's "reduce motion" OS/browser setting (accessibility). The
+// Santa→logo morph is mouse-driven, so it's only ever in motion while the user
+// moves the pointer; the one thing that animates on its own is the holiday
+// text's pulsing glow, which we hold steady when reduced motion is requested.
+const reducedMotionQuery =
+  window.matchMedia?.('(prefers-reduced-motion: reduce)');
+
 // ---------------------------------------------------------------------------
 // Initialization & Layout
 // ---------------------------------------------------------------------------
@@ -317,8 +324,11 @@ function drawHolidayMessage() {
   const textColor = lerpColor(COLOR_SANTA_SUIT_RED, COLOR_SANTA_BELT, lerpAmt);
 
   // 4. Holiday Styling: Dynamic Sparkle/Glow
-  // We use a sine wave based on time to make the glow pulse
-  const sparkle = 5 + Math.sin(Date.now() / 300) * 5;
+  // We use a sine wave based on time to make the glow pulse — unless the user
+  // prefers reduced motion, in which case we hold the glow steady.
+  const sparkle = reducedMotionQuery?.matches
+    ? 5
+    : 5 + Math.sin(Date.now() / 300) * 5;
   ctx.shadowColor = 'rgba(255, 255, 255, 0.9)';
   ctx.shadowBlur = sparkle;
   

--- a/src/apps/makelogo/MakeabilityLabLogo-SantaMorph/style.css
+++ b/src/apps/makelogo/MakeabilityLabLogo-SantaMorph/style.css
@@ -24,3 +24,18 @@ canvas {
   width: 100%;
   height: 100%;
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/makelogo/MakeabilityLabLogo/index.html
+++ b/src/apps/makelogo/MakeabilityLabLogo/index.html
@@ -18,6 +18,10 @@
 
 <body>
   <main class="container">
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Makeability Lab Logo</h1>
     <canvas id="myCanvas" role="img"
       aria-label="The animated Makeability Lab logo, drawn as a grid of colored triangles"></canvas>
   </main>

--- a/src/apps/makelogo/MakeabilityLabLogo/style.css
+++ b/src/apps/makelogo/MakeabilityLabLogo/style.css
@@ -9,3 +9,18 @@ canvas {
   width: 400px;
   height: 400px;
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/makelogo/MakeabilityLabLogoGridFade/index.html
+++ b/src/apps/makelogo/MakeabilityLabLogoGridFade/index.html
@@ -17,6 +17,10 @@
 
 <body>
   <main>
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Makeability Lab Logo — Grid Fade</h1>
     <canvas id="myCanvas" role="img"
       aria-label="Animation: a grid of triangles fades in, then the Makeability Lab logo appears"></canvas>
     <p class="hint hint-desktop">Press <kbd>R</kbd> to replay · <kbd>G</kbd> toggle grid · <kbd>H</kbd> toggle logo</p>

--- a/src/apps/makelogo/MakeabilityLabLogoGridFade/sketch.js
+++ b/src/apps/makelogo/MakeabilityLabLogoGridFade/sketch.js
@@ -33,6 +33,16 @@ const ctx = canvas.getContext('2d');
 let makeLabLogo;
 let gridFade;
 let animationStartMs = 0;
+let rafId = 0;
+
+// Respect the user's "reduce motion" OS/browser setting (accessibility). When
+// it's on, we skip the reveal animation and just show the finished logo.
+const reducedMotionQuery =
+  window.matchMedia?.('(prefers-reduced-motion: reduce)');
+
+// A timestamp well past the end of the reveal. Every piece clamps its progress
+// to 1, so updating with this settles the whole animation to its final frame.
+const SETTLE_MS = 10_000_000;
 
 /**
  * (Re)builds the canvas, logo, and animation for the current window size.
@@ -95,7 +105,30 @@ function frame(now) {
   gridFade.update(elapsedMs);
   gridFade.draw(ctx);
 
-  requestAnimationFrame(frame);
+  rafId = requestAnimationFrame(frame);
+}
+
+/** Draws the finished logo as a single static frame (no motion). */
+function drawSettledFrame() {
+  ctx.fillStyle = BACKGROUND_COLOR;
+  ctx.fillRect(0, 0, window.innerWidth, window.innerHeight);
+  gridFade.update(SETTLE_MS);
+  gridFade.draw(ctx);
+}
+
+/**
+ * Plays the reveal animation — or, if the user prefers reduced motion, draws
+ * the finished logo as one static frame instead of animating.
+ */
+function start() {
+  cancelAnimationFrame(rafId);
+  gridFade.reset();
+  animationStartMs = 0;
+  if (reducedMotionQuery?.matches) {
+    drawSettledFrame();
+  } else {
+    rafId = requestAnimationFrame(frame);
+  }
 }
 
 // Rebuild on resize (debounced). The clock keeps running, so an already-revealed
@@ -103,7 +136,11 @@ function frame(now) {
 let resizeTimer;
 window.addEventListener('resize', () => {
   clearTimeout(resizeTimer);
-  resizeTimer = setTimeout(buildScene, 150);
+  resizeTimer = setTimeout(() => {
+    buildScene();
+    // No loop runs under reduced motion, so repaint the static frame ourselves.
+    if (reducedMotionQuery?.matches) drawSettledFrame();
+  }, 150);
 });
 
 // --- Interaction ---
@@ -139,4 +176,8 @@ document.addEventListener('keydown', (event) => {
 });
 
 buildScene();
-requestAnimationFrame(frame);
+start();
+
+// If the user toggles "reduce motion" while the page is open, react live
+// (start animating, or settle to the static frame) without a reload.
+reducedMotionQuery?.addEventListener?.('change', start);

--- a/src/apps/makelogo/MakeabilityLabLogoGridFade/style.css
+++ b/src/apps/makelogo/MakeabilityLabLogoGridFade/style.css
@@ -57,3 +57,18 @@ kbd {
     display: block;
   }
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/makelogo/MakeabilityLabLogoLeafFall/index.html
+++ b/src/apps/makelogo/MakeabilityLabLogoLeafFall/index.html
@@ -17,6 +17,10 @@
 
 <body>
   <main>
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Makeability Lab Logo — Leaf Fall</h1>
     <canvas id="myCanvas" role="img"
       aria-label="Animation: triangles flutter down from the top like falling leaves, then the Makeability Lab logo's pieces fall into place"></canvas>
     <p class="hint hint-desktop">Press <kbd>R</kbd> to replay · <kbd>F</kbd> drop leaves · <kbd>T</kbd> toggle leaf fade · <kbd>G</kbd> toggle grid · <kbd>H</kbd> toggle logo</p>

--- a/src/apps/makelogo/MakeabilityLabLogoLeafFall/sketch.js
+++ b/src/apps/makelogo/MakeabilityLabLogoLeafFall/sketch.js
@@ -34,6 +34,16 @@ const ctx = canvas.getContext('2d');
 let makeLabLogo;
 let leafFall;
 let animationStartMs = 0;
+let rafId = 0;
+
+// Respect the user's "reduce motion" OS/browser setting (accessibility). When
+// it's on, we skip the falling animation and just show the finished logo.
+const reducedMotionQuery =
+  window.matchMedia?.('(prefers-reduced-motion: reduce)');
+
+// A timestamp well past the end of the fall. Every piece clamps its progress
+// to 1, so updating with this settles the whole animation to its final frame.
+const SETTLE_MS = 10_000_000;
 
 /**
  * (Re)builds the canvas, logo, and animation for the current window size.
@@ -94,7 +104,30 @@ function frame(now) {
   leafFall.update(elapsedMs);
   leafFall.draw(ctx);
 
-  requestAnimationFrame(frame);
+  rafId = requestAnimationFrame(frame);
+}
+
+/** Draws the finished logo as a single static frame (no motion). */
+function drawSettledFrame() {
+  ctx.fillStyle = BACKGROUND_COLOR;
+  ctx.fillRect(0, 0, window.innerWidth, window.innerHeight);
+  leafFall.update(SETTLE_MS);
+  leafFall.draw(ctx);
+}
+
+/**
+ * Plays the falling animation — or, if the user prefers reduced motion, draws
+ * the finished logo as one static frame instead of animating.
+ */
+function start() {
+  cancelAnimationFrame(rafId);
+  leafFall.reset();
+  animationStartMs = 0;
+  if (reducedMotionQuery?.matches) {
+    drawSettledFrame();
+  } else {
+    rafId = requestAnimationFrame(frame);
+  }
 }
 
 // Rebuild on resize (debounced). The clock keeps running, so an already-revealed
@@ -102,7 +135,11 @@ function frame(now) {
 let resizeTimer;
 window.addEventListener('resize', () => {
   clearTimeout(resizeTimer);
-  resizeTimer = setTimeout(buildScene, 150);
+  resizeTimer = setTimeout(() => {
+    buildScene();
+    // No loop runs under reduced motion, so repaint the static frame ourselves.
+    if (reducedMotionQuery?.matches) drawSettledFrame();
+  }, 150);
 });
 
 // --- Interaction ---
@@ -144,4 +181,8 @@ document.addEventListener('keydown', (event) => {
 });
 
 buildScene();
-requestAnimationFrame(frame);
+start();
+
+// If the user toggles "reduce motion" while the page is open, react live
+// (start animating, or settle to the static frame) without a reload.
+reducedMotionQuery?.addEventListener?.('change', start);

--- a/src/apps/makelogo/MakeabilityLabLogoLeafFall/style.css
+++ b/src/apps/makelogo/MakeabilityLabLogoLeafFall/style.css
@@ -57,3 +57,18 @@ kbd {
     display: block;
   }
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/makelogo/MakeabilityLabLogoZoomFade/index.html
+++ b/src/apps/makelogo/MakeabilityLabLogoZoomFade/index.html
@@ -17,6 +17,10 @@
 
 <body>
   <main>
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Makeability Lab Logo — Z-Zoom</h1>
     <canvas id="myCanvas" role="img"
       aria-label="Animation: triangles fly in from the front of the screen, shrinking and fading to fit, then the Makeability Lab logo's pieces zoom into place"></canvas>
     <p class="hint hint-desktop">Press <kbd>R</kbd> to replay · <kbd>G</kbd> toggle grid · <kbd>H</kbd> toggle logo</p>

--- a/src/apps/makelogo/MakeabilityLabLogoZoomFade/sketch.js
+++ b/src/apps/makelogo/MakeabilityLabLogoZoomFade/sketch.js
@@ -34,6 +34,16 @@ const ctx = canvas.getContext('2d');
 let makeLabLogo;
 let zoomFade;
 let animationStartMs = 0;
+let rafId = 0;
+
+// Respect the user's "reduce motion" OS/browser setting (accessibility). When
+// it's on, we skip the zoom animation and just show the finished logo.
+const reducedMotionQuery =
+  window.matchMedia?.('(prefers-reduced-motion: reduce)');
+
+// A timestamp well past the end of the zoom. Every piece clamps its progress
+// to 1, so updating with this settles the whole animation to its final frame.
+const SETTLE_MS = 10_000_000;
 
 /**
  * (Re)builds the canvas, logo, and animation for the current window size.
@@ -96,7 +106,30 @@ function frame(now) {
   zoomFade.update(elapsedMs);
   zoomFade.draw(ctx);
 
-  requestAnimationFrame(frame);
+  rafId = requestAnimationFrame(frame);
+}
+
+/** Draws the finished logo as a single static frame (no motion). */
+function drawSettledFrame() {
+  ctx.fillStyle = BACKGROUND_COLOR;
+  ctx.fillRect(0, 0, window.innerWidth, window.innerHeight);
+  zoomFade.update(SETTLE_MS);
+  zoomFade.draw(ctx);
+}
+
+/**
+ * Plays the zoom animation — or, if the user prefers reduced motion, draws the
+ * finished logo as one static frame instead of animating.
+ */
+function start() {
+  cancelAnimationFrame(rafId);
+  zoomFade.reset();
+  animationStartMs = 0;
+  if (reducedMotionQuery?.matches) {
+    drawSettledFrame();
+  } else {
+    rafId = requestAnimationFrame(frame);
+  }
 }
 
 // Rebuild on resize (debounced). The clock keeps running, so an already-revealed
@@ -104,7 +137,11 @@ function frame(now) {
 let resizeTimer;
 window.addEventListener('resize', () => {
   clearTimeout(resizeTimer);
-  resizeTimer = setTimeout(buildScene, 150);
+  resizeTimer = setTimeout(() => {
+    buildScene();
+    // No loop runs under reduced motion, so repaint the static frame ourselves.
+    if (reducedMotionQuery?.matches) drawSettledFrame();
+  }, 150);
 });
 
 // --- Interaction ---
@@ -140,4 +177,8 @@ document.addEventListener('keydown', (event) => {
 });
 
 buildScene();
-requestAnimationFrame(frame);
+start();
+
+// If the user toggles "reduce motion" while the page is open, react live
+// (start animating, or settle to the static frame) without a reload.
+reducedMotionQuery?.addEventListener?.('change', start);

--- a/src/apps/makelogo/MakeabilityLabLogoZoomFade/style.css
+++ b/src/apps/makelogo/MakeabilityLabLogoZoomFade/style.css
@@ -57,3 +57,18 @@ kbd {
     display: block;
   }
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/makelogo/TriangleArtMorphTest/index.html
+++ b/src/apps/makelogo/TriangleArtMorphTest/index.html
@@ -28,6 +28,10 @@
   </div>
 
   <main class="container">
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Makeability Lab Shape Morph</h1>
     <canvas id="myCanvas" role="img"
       aria-label="Animation: triangle-grid art morphing between holiday shapes"></canvas>
   </main>

--- a/src/apps/makelogo/TriangleArtMorphTest/style.css
+++ b/src/apps/makelogo/TriangleArtMorphTest/style.css
@@ -39,3 +39,18 @@ canvas {
 }
 label { font-weight: bold; margin-right: 8px; }
 select { font-size: 14px; padding: 6px; border-radius: 4px; border: 1px solid #ccc; }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/apps/makelogo/TriangleArtMorphTest2-MorphLib/index.html
+++ b/src/apps/makelogo/TriangleArtMorphTest2-MorphLib/index.html
@@ -105,6 +105,10 @@
   </div>
 
   <main class="container">
+    <!-- Visually hidden heading: gives screen-reader users a proper page title
+         to navigate by. The canvas is just an image, so without this the page
+         would have no heading. Hidden from sighted users via .visually-hidden. -->
+    <h1 class="visually-hidden">Makeability Lab Shape Morph</h1>
     <canvas id="myCanvas" role="img"
       aria-label="Animation: the Makeability Lab logo morphing between shapes using the morph library"></canvas>
   </main>

--- a/src/apps/makelogo/TriangleArtMorphTest2-MorphLib/style.css
+++ b/src/apps/makelogo/TriangleArtMorphTest2-MorphLib/style.css
@@ -154,3 +154,18 @@ select {
   opacity: 0.4;
   pointer-events: none;
 }
+
+/* Visually hidden: removed from view but kept in the accessibility tree so the
+   <h1> page heading is available for screen-reader navigation. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Addresses the two follow-ups from #5 (the June 2026 a11y pass).

## Changes

**Visually-hidden `<h1>` per demo (14 canvas apps)** — adds a shared `.visually-hidden` utility to each app's `style.css` (inline `<style>` for `basic/Basic`, which has no stylesheet) and an `<h1>` as the first child of `<main>`, each prefaced with a short comment explaining its purpose. Completes the document heading structure for screen-reader navigation with no visual change. `MorphPaths` already has a visible `<h1>`, so it's left as-is.

**`prefers-reduced-motion`** — freezes the autonomous, auto-playing demos (BouncyBall, GridFade, LeafFall, ZoomFade): they render a single settled frame instead of starting the rAF loop, react live to the setting changing, and repaint the static frame on resize. `SantaMorph`'s morph is mouse-driven, so only its self-pulsing text glow is held steady. The remaining morph demos (`TriangleArtMorphTest`, `TriangleArtMorphTest2`, `MorphPaths`, `ReverseExplosion`/`2`) are mouse-driven direct manipulation and are intentionally left untouched.

## Verification

Driven in Chrome via Playwright: reduced motion freezes the loop while no-preference animates, and the hidden `<h1>` is exposed as a heading in the accessibility tree while clipped to 1×1px visually. All modified JS passes `node --check`.

No `src/lib/` changes → no `dist/` rebuild needed. Gallery and `previews/` are CI-regenerated on push.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)